### PR TITLE
feat: SAT now also returns the contact type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ file(GLOB_RECURSE TEST_SOURCES "tests/*.cpp")
 add_executable(unit_tests ${TEST_SOURCES})
 target_include_directories(unit_tests
     PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests
         ${CMAKE_CURRENT_SOURCE_DIR}/include
         ${CMAKE_CURRENT_SOURCE_DIR}/src
 )

--- a/examples/0_collision_detection/main.cpp
+++ b/examples/0_collision_detection/main.cpp
@@ -128,9 +128,11 @@ class Dev : public Game {
         }
 
         if (collision_point.has_value()) {
-            RenderBody r = RenderBody{.color = glm::vec3(1.0, 1.0, 0.0),
-                                      .position = collision_point->collision_point,
-                                      .shape = Shape::create_rectangle_data(10.0, 10.0)};
+            RenderBody r = RenderBody{
+                .color = glm::vec3(1.0, 1.0, 0.0),
+                .position =
+                    collision_point->contact_patch[collision_point->deepest_contact_idx],
+                .shape = Shape::create_rectangle_data(10.0, 10.0)};
             render_bodies.push_back(std::cref(r));
         }
 

--- a/include/equations/equations.h
+++ b/include/equations/equations.h
@@ -5,6 +5,7 @@
 struct Equations {
 
     static float length2(const glm::vec3 &v);
+    static float distance2(const glm::vec3 &p1, const glm::vec3 &p2);
     static float cross_2d(const glm::vec3 &v1, const glm::vec3 &v2);
 
     static glm::vec3 counterclockwise_perp_z(const glm::vec3 &);

--- a/include/io.h
+++ b/include/io.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "glm/fwd.hpp"
-#include "physics_engine/SAT.h"
 #include <iostream>
 #include <string>
 
@@ -10,4 +9,4 @@ std::string vec_to_string(const glm::vec2 &vec);
 std::string mat_to_string(const glm::mat3 &mat);
 
 std::ostream &operator<<(std::ostream &os, const glm::vec3 &vec);
-std::ostream &operator<<(std::ostream &os, const CollisionInformation &ci);
+std::ostream &operator<<(std::ostream &os, const std::vector<glm::vec3> &vec);

--- a/include/physics_engine/SAT.h
+++ b/include/physics_engine/SAT.h
@@ -3,10 +3,17 @@
 #include <glm/glm.hpp>
 #include <optional>
 
+enum class ContactType { NONE, VERTEX_VERTEX, VERTEX_EDGE, EDGE_EDGE };
+std::ostream &operator<<(std::ostream &os, const ContactType &c);
+
 struct CollisionInformation {
     float penetration_depth;
     glm::vec3 normal;
-    glm::vec3 collision_point;
+    /*glm::vec3 collision_point; // TODO: remove*/
+
+    ContactType contact_type;
+    std::vector<glm::vec3> contact_patch;
+    size_t deepest_contact_idx;
 };
 
 class SAT {
@@ -17,3 +24,5 @@ class SAT {
     static std::optional<CollisionInformation> collision_detection(const RigidBody &,
                                                                    const RigidBody &);
 };
+
+std::ostream &operator<<(std::ostream &os, const CollisionInformation &ci);

--- a/include/physics_engine/SAT.h
+++ b/include/physics_engine/SAT.h
@@ -9,8 +9,6 @@ std::ostream &operator<<(std::ostream &os, const ContactType &c);
 struct CollisionInformation {
     float penetration_depth;
     glm::vec3 normal;
-    /*glm::vec3 collision_point; // TODO: remove*/
-
     ContactType contact_type;
     std::vector<glm::vec3> contact_patch;
     size_t deepest_contact_idx;

--- a/src/equations/equations.cpp
+++ b/src/equations/equations.cpp
@@ -3,6 +3,10 @@
 
 float Equations::length2(const glm::vec3 &v) { return v.x * v.x + v.y * v.y + v.z * v.z; }
 
+float Equations::distance2(const glm::vec3 &p1, const glm::vec3 &p2) {
+    return length2(p2 - p1);
+}
+
 float Equations::cross_2d(const glm::vec3 &v1, const glm::vec3 &v2) {
     return v1.x * v2.y - v1.y * v2.x;
 }

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -15,6 +15,15 @@ std::ostream &operator<<(std::ostream &os, const glm::vec3 &vec) {
     return os;
 }
 
+std::ostream &operator<<(std::ostream &os, const std::vector<glm::vec3> &vec) {
+    os << "[ ";
+    for (auto v : vec) {
+        os << v << ", ";
+    }
+    os << "]";
+    return os;
+}
+
 std::string vec_to_string(const glm::vec2 &vec) {
     std::ostringstream oss;
     oss << "glm::vec2(" << vec.x << ", " << vec.y << ")";
@@ -29,10 +38,4 @@ std::string mat_to_string(const glm::mat3x3 &mat) {
         << mat[2].x << ", " << mat[2].y << ", " << mat[2].z << std::endl
         << ")";
     return oss.str();
-}
-
-std::ostream &operator<<(std::ostream &os, const CollisionInformation &ci) {
-    os << "CollisionInformation( point: " << ci.collision_point
-       << ", normal: " << ci.normal << ", depth: " << ci.penetration_depth << ")";
-    return os;
 }

--- a/src/physics_engine/SAT.cpp
+++ b/src/physics_engine/SAT.cpp
@@ -3,8 +3,6 @@
 #include "equations/projection.h"
 #include "glm/geometric.hpp"
 #include "io.h"
-#include <algorithm>
-#include <cfloat>
 #include <iostream>
 #include <optional>
 #include <vector>
@@ -16,20 +14,10 @@ struct CollisionEdge {
     glm::vec3 edge;
 };
 
-/*struct ClippedPoint {*/
-/*    glm::vec3 vertex;*/
-/*    float depth;*/
-/*};*/
-
 struct MTV {
     glm::vec3 direction;
     float magnitude;
 };
-
-/*std::ostream &operator<<(std::ostream &os, const ClippedPoint &cp) {*/
-/*    os << "ClippedPoint( vertex: " << cp.vertex << ", depth: " << cp.depth << ")";*/
-/*    return os;*/
-/*}*/
 
 std::ostream &operator<<(std::ostream &os, const CollisionEdge &ce) {
     os << "CollisionEdge( start: " << ce.start << ", end: " << ce.end
@@ -187,8 +175,6 @@ CollisionInformation find_clipping_points(const CollisionEdge &edge_a,
     std::vector<glm::vec3> clipped_points =
         sat_clip(incident_edge.start, incident_edge.end, reference_edge.edge, offset_1);
 
-    /*std::cout << "First clip: " << clipped_points << std::endl;*/
-
     if (clipped_points.size() < 2) {
         return {};
     }
@@ -196,8 +182,6 @@ CollisionInformation find_clipping_points(const CollisionEdge &edge_a,
     const float offset_2 = glm::dot(reference_edge.edge, reference_edge.end);
     clipped_points =
         sat_clip(clipped_points[0], clipped_points[1], -reference_edge.edge, -offset_2);
-
-    /*std::cout << "Second clip: " << clipped_points << std::endl;*/
 
     if (clipped_points.size() < 2) {
         return {};
@@ -213,8 +197,6 @@ CollisionInformation find_clipping_points(const CollisionEdge &edge_a,
     std::vector<glm::vec3> contact_patch;
     for (size_t i = 0; i < clipped_points.size(); i++) {
         float depth = glm::dot(reference_edge_norm, clipped_points[i]) - max;
-        /*std::cout << "Depth: " << depth << ", point: " << clipped_points[i] <<
-         * std::endl;*/
         if (depth >= 0.0f) {
             contact_patch.push_back(std::move(clipped_points[i]));
             if (max_depth < depth) {
@@ -223,8 +205,6 @@ CollisionInformation find_clipping_points(const CollisionEdge &edge_a,
             }
         }
     }
-
-    /*std::cout << "Final clip: " << contact_patch << std::endl;*/
 
     ContactType contact_type =
         determine_contact_type(contact_patch, reference_edge, incident_edge);
@@ -303,19 +283,4 @@ std::optional<CollisionInformation> SAT::collision_detection(const RigidBody &bo
     }
 
     return info;
-    // Find deepest penetration point
-    // TODO: Remove
-    /*const auto deepest_point = std::max_element(*/
-    /*    clipping_points.begin(), clipping_points.end(),*/
-    /*    [](const ClippedPoint &a, const ClippedPoint &b) { return a.depth <
-     * b.depth;
-     * });*/
-    /**/
-    /*if (deepest_point == clipping_points.end()) {*/
-    /*    return std::nullopt;*/
-    /*}*/
-
-    /*return CollisionInformation{.penetration_depth = deepest_point->depth,*/
-    /*                            .normal = collision_normal,*/
-    /*                            .collision_point = deepest_point->vertex};*/
 }

--- a/src/physics_engine/SAT.cpp
+++ b/src/physics_engine/SAT.cpp
@@ -4,6 +4,7 @@
 #include "glm/geometric.hpp"
 #include "io.h"
 #include <algorithm>
+#include <cfloat>
 #include <iostream>
 #include <optional>
 #include <vector>
@@ -15,20 +16,20 @@ struct CollisionEdge {
     glm::vec3 edge;
 };
 
-struct ClippedPoint {
-    glm::vec3 vertex;
-    float depth;
-};
+/*struct ClippedPoint {*/
+/*    glm::vec3 vertex;*/
+/*    float depth;*/
+/*};*/
 
 struct MTV {
     glm::vec3 direction;
     float magnitude;
 };
 
-std::ostream &operator<<(std::ostream &os, const ClippedPoint &cp) {
-    os << "ClippedPoint( vertex: " << cp.vertex << ", depth: " << cp.depth << ")";
-    return os;
-}
+/*std::ostream &operator<<(std::ostream &os, const ClippedPoint &cp) {*/
+/*    os << "ClippedPoint( vertex: " << cp.vertex << ", depth: " << cp.depth << ")";*/
+/*    return os;*/
+/*}*/
 
 std::ostream &operator<<(std::ostream &os, const CollisionEdge &ce) {
     os << "CollisionEdge( start: " << ce.start << ", end: " << ce.end
@@ -41,9 +42,30 @@ std::ostream &operator<<(std::ostream &os, const MTV &mtv) {
     return os;
 }
 
+std::ostream &operator<<(std::ostream &os, const ContactType &c) {
+    switch (c) {
+    case ContactType::VERTEX_VERTEX:
+        return os << "ContactType::VERTEX_VERTEX";
+    case ContactType::VERTEX_EDGE:
+        return os << "ContactType::VERTEX_EDGE";
+    case ContactType::EDGE_EDGE:
+        return os << "ContactType::EDGE_EDGE";
+    default:
+        return os << "ContactType::NONE";
+    }
+}
+
+std::ostream &operator<<(std::ostream &os, const CollisionInformation &ci) {
+    os << "CollisionInformation( contact_type: " << ci.contact_type
+       << " ,contact_patch: " << ci.contact_patch << ", normal: " << ci.normal
+       << ", depth: " << ci.penetration_depth
+       << ", deepest_contact_idx: " << ci.deepest_contact_idx << " )";
+    return os;
+}
+
 // Find the edge most aligned with the collision axis
-CollisionEdge sat_find_collision_edge(const RigidBody &body,
-                                      const glm::vec3 &collision_axis) {
+CollisionEdge find_collision_edge(const RigidBody &body,
+                                  const glm::vec3 &collision_axis) {
     auto vertices = body.vertices();
 
     // Find vertex with maximum projection along collision axis
@@ -58,31 +80,15 @@ CollisionEdge sat_find_collision_edge(const RigidBody &body,
         }
     }
 
-    /*std::cout << std::endl;*/
-    /*std::cout << "Collision axis: " << collision_axis << std::endl;*/
-    /*std::cout << "Index: " << index << std::endl;*/
-    /*std::cout << std::endl;*/
-
     const int num_vertices = vertices.size();
     const glm::vec3 prev_vertex = vertices[(index - 1 + num_vertices) % num_vertices];
     const glm::vec3 mid_vertex = vertices[index];
     const glm::vec3 next_vertex = vertices[(index + 1 + num_vertices) % num_vertices];
 
-    /*std::cout << std::endl;*/
-    /*std::cout << "prev_vert: " << prev_vertex << std::endl;*/
-    /*std::cout << "mid_vert: " << mid_vertex << std::endl;*/
-    /*std::cout << "next_vert: " << next_vertex << std::endl;*/
-    /*std::cout << std::endl;*/
-
     // Be careful when computing the left and right (l and r in the code above) vectors as
     // they both must point towards the maximum point
     glm::vec3 left_edge = mid_vertex - next_vertex;
     glm::vec3 right_edge = mid_vertex - prev_vertex;
-
-    /*std::cout << std::endl;*/
-    /*std::cout << "left edge: " << left_edge << std::endl;*/
-    /*std::cout << "right edge: " << right_edge << std::endl;*/
-    /*std::cout << std::endl;*/
 
     // Normalize edge vectors
     left_edge = glm::normalize(left_edge);
@@ -128,16 +134,38 @@ std::vector<glm::vec3> sat_clip(const glm::vec3 &v1, const glm::vec3 &v2,
     return clipped_points;
 }
 
+ContactType determine_contact_type(const std::vector<glm::vec3> &clipping_points,
+                                   const CollisionEdge &ref_edge,
+                                   const CollisionEdge &inc_edge) {
+
+    if (clipping_points.size() > 1) {
+        // Dot product close to 1 or -1 indicates parallel edges (edges are already
+        // normalized)
+        const float edge_alignment = std::abs(glm::dot(ref_edge.edge, inc_edge.edge));
+        constexpr float alignment_threshold = 0.996; // Roughly within +-5 degrees
+        if (edge_alignment > alignment_threshold) {
+            return ContactType::EDGE_EDGE;
+        }
+    }
+
+    if (clipping_points.size() == 1) {
+        const glm::vec3 &point = clipping_points[0];
+        // Clipping point is always on the incident edge, therefor we only check for
+        // proximity to reference edge start and stop
+        const float distance_start = Equations::distance2(point, ref_edge.start);
+        const float distance_end = Equations::distance2(point, ref_edge.end);
+        constexpr float distance_threshold = 0.01f;
+        if (distance_start < distance_threshold || distance_end < distance_threshold) {
+            return ContactType::VERTEX_VERTEX;
+        }
+    }
+    return ContactType::VERTEX_EDGE;
+}
+
 // Find clipping points between two bodies in collision
-std::vector<ClippedPoint> sat_find_clipping_points(const RigidBody &body_a,
-                                                   const RigidBody &body_b,
-                                                   const glm::vec3 &collision_normal) {
-    auto edge_a = sat_find_collision_edge(body_a, collision_normal);
-    auto edge_b = sat_find_collision_edge(body_b, -collision_normal);
-
-    /*std::cout << "Body A: " << edge_a << std::endl;*/
-    /*std::cout << "Body B: " << edge_b << std::endl;*/
-
+CollisionInformation find_clipping_points(const CollisionEdge &edge_a,
+                                          const CollisionEdge &edge_b,
+                                          const glm::vec3 &collision_normal) {
     // Choose reference edge (the one most perpendicular to collision normal)
     bool flip = false;
     CollisionEdge reference_edge, incident_edge;
@@ -152,40 +180,62 @@ std::vector<ClippedPoint> sat_find_clipping_points(const RigidBody &body_a,
         flip = true;
     }
 
-    /*std::cout << "Reference edge: " << reference_edge << std::endl;*/
-    /*std::cout << "Incident edge: " << incident_edge << std::endl;*/
-
     reference_edge.edge = glm::normalize(reference_edge.edge);
+    incident_edge.edge = glm::normalize(incident_edge.edge);
 
-    float offset_1 = glm::dot(reference_edge.edge, reference_edge.start);
+    const float offset_1 = glm::dot(reference_edge.edge, reference_edge.start);
     std::vector<glm::vec3> clipped_points =
         sat_clip(incident_edge.start, incident_edge.end, reference_edge.edge, offset_1);
 
+    /*std::cout << "First clip: " << clipped_points << std::endl;*/
+
     if (clipped_points.size() < 2) {
         return {};
     }
 
-    float offset_2 = glm::dot(reference_edge.edge, reference_edge.end);
+    const float offset_2 = glm::dot(reference_edge.edge, reference_edge.end);
     clipped_points =
         sat_clip(clipped_points[0], clipped_points[1], -reference_edge.edge, -offset_2);
 
+    /*std::cout << "Second clip: " << clipped_points << std::endl;*/
+
     if (clipped_points.size() < 2) {
         return {};
     }
 
-    glm::vec3 reference_edge_norm =
+    const glm::vec3 reference_edge_norm =
         Equations::counterclockwise_perp_z(reference_edge.edge);
-    float max = glm::dot(reference_edge_norm, reference_edge.max);
+    const float max = glm::dot(reference_edge_norm, reference_edge.max);
 
-    std::vector<ClippedPoint> result;
-    for (const auto &point : clipped_points) {
-        float depth = glm::dot(reference_edge_norm, point) - max;
+    // Final clipping
+    float max_depth = 0.0;
+    size_t max_depth_idx = 0;
+    std::vector<glm::vec3> contact_patch;
+    for (size_t i = 0; i < clipped_points.size(); i++) {
+        float depth = glm::dot(reference_edge_norm, clipped_points[i]) - max;
+        /*std::cout << "Depth: " << depth << ", point: " << clipped_points[i] <<
+         * std::endl;*/
         if (depth >= 0.0f) {
-            result.push_back(ClippedPoint{.vertex = point, .depth = depth});
+            contact_patch.push_back(std::move(clipped_points[i]));
+            if (max_depth < depth) {
+                max_depth = depth;
+                max_depth_idx = i;
+            }
         }
     }
 
-    return result;
+    /*std::cout << "Final clip: " << contact_patch << std::endl;*/
+
+    ContactType contact_type =
+        determine_contact_type(contact_patch, reference_edge, incident_edge);
+
+    return CollisionInformation{
+        .penetration_depth = max_depth,
+        .deepest_contact_idx = max_depth_idx,
+        .normal = std::move(collision_normal),
+        .contact_patch = std::move(contact_patch),
+        .contact_type = contact_type,
+    };
 }
 
 std::optional<MTV> find_mtv(const RigidBody &body_a, const RigidBody &body_b) {
@@ -238,24 +288,34 @@ std::optional<CollisionInformation> SAT::collision_detection(const RigidBody &bo
                                                              const RigidBody &body_b) {
     auto mtv = find_mtv(body_a, body_b);
     if (!mtv.has_value()) {
-        /*std::cout << "No collision" << std::endl;*/
         return std::nullopt;
     }
-    glm::vec3 collision_normal = mtv.value().direction;
 
-    std::vector<ClippedPoint> clipping_points =
-        sat_find_clipping_points(body_a, body_b, collision_normal);
+    const glm::vec3 collision_normal = mtv.value().direction;
 
+    auto edge_a = find_collision_edge(body_a, collision_normal);
+    auto edge_b = find_collision_edge(body_b, -collision_normal);
+
+    CollisionInformation info = find_clipping_points(edge_a, edge_b, collision_normal);
+
+    if (info.contact_patch.empty()) {
+        return std::nullopt;
+    }
+
+    return info;
     // Find deepest penetration point
-    auto deepest_point = std::max_element(
-        clipping_points.begin(), clipping_points.end(),
-        [](const ClippedPoint &a, const ClippedPoint &b) { return a.depth < b.depth; });
+    // TODO: Remove
+    /*const auto deepest_point = std::max_element(*/
+    /*    clipping_points.begin(), clipping_points.end(),*/
+    /*    [](const ClippedPoint &a, const ClippedPoint &b) { return a.depth <
+     * b.depth;
+     * });*/
+    /**/
+    /*if (deepest_point == clipping_points.end()) {*/
+    /*    return std::nullopt;*/
+    /*}*/
 
-    if (deepest_point == clipping_points.end()) {
-        return std::nullopt;
-    }
-
-    return CollisionInformation{.penetration_depth = deepest_point->depth,
-                                .normal = collision_normal,
-                                .collision_point = deepest_point->vertex};
+    /*return CollisionInformation{.penetration_depth = deepest_point->depth,*/
+    /*                            .normal = collision_normal,*/
+    /*                            .collision_point = deepest_point->vertex};*/
 }

--- a/src/physics_engine/collision_resolver.cpp
+++ b/src/physics_engine/collision_resolver.cpp
@@ -16,7 +16,7 @@ std::ostream &operator<<(std::ostream &os, const CollisionCorrections &c) {
 std::optional<CollisionCorrections>
 resolve_collision(const CollisionInformation &ci, RigidBody &body_a, RigidBody &body_b) {
 
-    glm::vec3 p = ci.collision_point;
+    glm::vec3 p = ci.contact_patch[ci.deepest_contact_idx];
     glm::vec3 collision_normal = ci.normal;
     float penetration_depth = ci.penetration_depth;
 
@@ -89,17 +89,4 @@ resolve_collision(const CollisionInformation &ci, RigidBody &body_a, RigidBody &
             },
     };
     return corrections;
-    /*std::cout << "Body A position correction: " << body_a_pos_correction <<
-       std::endl;*/
-    /*std::cout << "Body B position correction: " << body_b_pos_correction <<
-       std::endl;*/
-    /*body_a.position += body_a_pos_correction;*/
-    /*body_a.velocity += body_a_post_collision_vel;*/
-    /*body_a.prev_position = WorldPoint(body_a.position - body_a.velocity);*/
-    /*body_a.angular_velocity += body_a_post_collision_angular_vel;*/
-    /**/
-    /*body_b.position += body_b_pos_correction;*/
-    /*body_b.velocity += body_b_post_collision_vel;*/
-    /*body_b.prev_position = WorldPoint(body_b.position - body_b.velocity);*/
-    /*body_b.angular_velocity += body_b_post_collision_angular_vel;*/
 }

--- a/tests/collision_resolver_test.cpp
+++ b/tests/collision_resolver_test.cpp
@@ -3,28 +3,34 @@
 #include "physics_engine/RigidBody.h"
 #include "physics_engine/SAT.h"
 #include "physics_engine/collision_resolver.h"
+#include "test_utils.h"
 #include <gtest/gtest.h>
 
 TEST(CollisionResolverTest,
      GivenTwoRectanglesWhenTheyHaveNoVelocityExpectPositionalChange) {
 
-    RigidBody body_a = RigidBody{.position = WorldPoint(-4.0f, 0.0f, 0.0f),
-                                 .shape = Shape::create_rectangle_data(10.0f, 10.0f),
-                                 .mass = 1.0};
-    RigidBody body_b = RigidBody{.position = WorldPoint(4.0f, 0.0f, 0.0f),
-                                 .shape = Shape::create_rectangle_data(10.0f, 10.0f),
-                                 .mass = 1.0};
+    RigidBody body_a = RigidBodyBuilder()
+                           .position(WorldPoint(-4.0f, 0.0f, 0.0f))
+                           .shape(Shape::create_rectangle_data(10.0f, 10.0f))
+                           .mass(1.0)
+                           .build();
+    RigidBody body_b = RigidBodyBuilder()
+                           .position(WorldPoint(4.0f, 0.0f, 0.0f))
+                           .shape(Shape::create_rectangle_data(10.0f, 10.0f))
+                           .mass(1.0)
+                           .build();
 
-    std::optional<CollisionInformation> collision_info_ =
-        SAT::collision_detection(body_a, body_b);
-
+    const auto collision_info_ = SAT::collision_detection(body_a, body_b);
     EXPECT_TRUE(collision_info_.has_value());
+    const CollisionInformation collision_info = collision_info_.value();
 
-    CollisionInformation collision_info = collision_info_.value();
-
-    EXPECT_EQ(glm::vec3(1.0f, 0.0f, 0.0f), collision_info.normal);
-    EXPECT_EQ(2.0f, collision_info.penetration_depth);
-    EXPECT_EQ(glm::vec3(-1.0f, 5.0f, 0.0f), collision_info.collision_point);
+    EXPECT_EQ(ContactType::EDGE_EDGE, collision_info.contact_type);
+    EXPECT_EQ(2, collision_info.contact_patch.size());
+    expect_near(glm::vec3(-1.0f, 5.0f, 0.0f), collision_info.contact_patch[0], MAX_DIFF);
+    expect_near(glm::vec3(-1.0f, -5.0f, 0.0), collision_info.contact_patch[1], MAX_DIFF);
+    expect_near(glm::vec3(1.0f, 0.0, 0.0), collision_info.normal, MAX_DIFF);
+    EXPECT_NEAR(2.0f, collision_info.penetration_depth, MAX_DIFF);
+    EXPECT_EQ(0, collision_info.deepest_contact_idx);
 
     auto collision_corrections_ = resolve_collision(collision_info, body_a, body_b);
     EXPECT_TRUE(collision_corrections_.has_value());

--- a/tests/rigid_body_test.cpp
+++ b/tests/rigid_body_test.cpp
@@ -5,14 +5,8 @@
 #include "io.h"
 #include "physics_engine/RigidBody.h"
 #include "shape.h"
+#include "test_utils.h"
 #include <gtest/gtest.h>
-
-void expect_near_rigid_body_test(glm::vec3 &expected, glm::vec3 &v, float epsilon) {
-    std::cout << "Expected " << expected << " found " << v << std::endl;
-    EXPECT_NEAR(expected.x, v.x, epsilon);
-    EXPECT_NEAR(expected.y, v.y, epsilon);
-    EXPECT_NEAR(expected.z, v.z, epsilon);
-}
 
 TEST(RigidBodyTest, GivenRectangleAtOrigoCreatesExpectedVertices) {
     RigidBody test_body = RigidBody{.position = WorldPoint(0.0, 0.0, 0.0),
@@ -626,9 +620,9 @@ TEST(RigidBodyTest, GivenTriangleWhenAtOrigoProducesExpectedEdges) {
     };
 
     float max_diff = 1e-3f;
-    expect_near_rigid_body_test(expected[0], edges[0], max_diff);
-    expect_near_rigid_body_test(expected[1], edges[1], max_diff);
-    expect_near_rigid_body_test(expected[2], edges[2], max_diff);
+    expect_near(expected[0], edges[0], max_diff);
+    expect_near(expected[1], edges[1], max_diff);
+    expect_near(expected[2], edges[2], max_diff);
 }
 
 TEST(RigidBodyTest, GivenPointLeftOfRectangleExpectClosestPointOnBorder) {

--- a/tests/sat_test.cpp
+++ b/tests/sat_test.cpp
@@ -4,350 +4,435 @@
 #include "physics_engine/SAT.cpp"
 #include "physics_engine/SAT.h"
 #include "shape.h"
+#include "test_utils.h"
 #include <gtest/gtest.h>
 #include <optional>
 
-void expect_near(glm::vec3 &expected, glm::vec3 &v, float epsilon) {
-    std::cout << "Expected " << expected << " found " << v << std::endl;
-    EXPECT_NEAR(expected.x, v.x, epsilon);
-    EXPECT_NEAR(expected.y, v.y, epsilon);
-    EXPECT_NEAR(expected.z, v.z, epsilon);
-}
-
-void expect_near(CollisionInformation &expected, CollisionInformation &info,
-                 float epsilon) {
-    std::cout << "collision point (exp == val): "
-              << vec_to_string(expected.collision_point)
-              << " == " << vec_to_string(info.collision_point) << std::endl;
-    std::cout << "normal (exp == val): " << vec_to_string(expected.normal)
-              << " == " << vec_to_string(info.normal) << std::endl;
-
-    EXPECT_NEAR(expected.penetration_depth, info.penetration_depth, epsilon);
-    expect_near(expected.normal, info.normal, epsilon);
-    expect_near(expected.collision_point, info.collision_point, epsilon);
-}
-
-void expect_near(CollisionEdge &expected, CollisionEdge &v, float epsilon) {
+void expect_near(const CollisionEdge &expected, const CollisionEdge &v,
+                 const float epsilon) {
     expect_near(expected.max, v.max, epsilon);
     expect_near(expected.start, v.start, epsilon);
     expect_near(expected.end, v.end, epsilon);
     expect_near(expected.edge, v.edge, epsilon);
 }
 
-void expect_near(ClippedPoint &expected, ClippedPoint &c, float epsilon) {
-    expect_near(expected.vertex, c.vertex, epsilon);
-    EXPECT_NEAR(expected.depth, c.depth, epsilon);
-}
-
 TEST(SATTest, GivenRectanglesAreAxisAlignedWhenDoNotCollideExpectNoCollision) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(-10.0, 0.0, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(20.0, 10.0)};
-    RigidBody body_b = RigidBody{.position = WorldPoint(11.0, 0.0, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(20.0, 10.0)};
-    auto output = SAT::collision_detection(body_a, body_b);
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(-10.0, 0.0, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(20.0, 10.0))
+                                 .build();
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(11.0, 0.0, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(20.0, 10.0))
+                                 .build();
+    const auto output = SAT::collision_detection(body_a, body_b);
     EXPECT_FALSE(output.has_value());
 }
 
 TEST(SATTest, GivenRectanglesAreAxisAlignedWhenTouchOnYAxisExpectNoCollision) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(-10.0, 0.0, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(20.0, 10.0)};
-    RigidBody body_b = RigidBody{.position = WorldPoint(10.0, 0.0, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(20.0, 10.0)};
-    auto output = SAT::collision_detection(body_a, body_b);
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(-10.0, 0.0, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(20.0, 10.0))
+                                 .build();
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(10.0, 0.0, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(20.0, 10.0))
+                                 .build();
+    const auto output = SAT::collision_detection(body_a, body_b);
     EXPECT_FALSE(output.has_value());
 }
 
 TEST(SATTest, GivenRectanglesAreAxisAlignedWhenOverlapOnYAxisExpectCollision) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(-10.0, 0.0, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(20.0, 10.0)};
-    RigidBody body_b = RigidBody{.position = WorldPoint(9.0, 0.0, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(20.0, 10.0)};
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(-10.0, 0.0, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(20.0, 10.0))
+                                 .build();
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(9.0, 0.0, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(20.0, 10.0))
+                                 .build();
 
-    std::optional<CollisionInformation> output = SAT::collision_detection(body_a, body_b);
+    const std::optional<CollisionInformation> output_ =
+        SAT::collision_detection(body_a, body_b);
 
-    CollisionInformation expected = {.penetration_depth = 1.0,
-                                     .normal = glm::vec3(1.0, 0.0, 0.0),
-                                     .collision_point = glm::vec3(-1.0, 5.0, 0.0)};
-    float max_diff = 1e-3;
-    EXPECT_TRUE(output.has_value());
-    expect_near(expected, output.value(), max_diff);
+    EXPECT_TRUE(output_.has_value());
+
+    const CollisionInformation output = output_.value();
+    EXPECT_EQ(ContactType::EDGE_EDGE, output.contact_type);
+    EXPECT_EQ(2, output.contact_patch.size());
+    expect_near(glm::vec3(-1.0, 5.0, 0.0), output.contact_patch[0], MAX_DIFF);
+    expect_near(glm::vec3(-1.0, -5.0, 0.0), output.contact_patch[1], MAX_DIFF);
+    EXPECT_EQ(glm::vec3(1.0, 0.0, 0.0), output.normal);
+    EXPECT_EQ(1.0, output.penetration_depth);
+    EXPECT_EQ(0, output.deepest_contact_idx);
 }
 
 TEST(
     SATTest,
     GivenRectanglesAreAxisAlignedWhenOverlapOnYAxisButBodiesHaveSwappedOrderExpectCollision) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(9.0, 0.0, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(20.0, 10.0)};
-    RigidBody body_b = RigidBody{.position = WorldPoint(-10.0, 0.0, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(20.0, 10.0)};
-    auto output = SAT::collision_detection(body_a, body_b);
-    CollisionInformation expected = {.penetration_depth = 1.0,
-                                     .normal = glm::vec3(-1.0, 0.0, 0.0),
-                                     .collision_point = glm::vec3(0.0, -5.0, 0.0)};
-    float max_diff = 1e-3;
-    EXPECT_TRUE(output.has_value());
-    expect_near(expected, output.value(), max_diff);
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(9.0, 0.0, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(20.0, 10.0))
+                                 .build();
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(-10.0, 0.0, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(20.0, 10.0))
+                                 .build();
+    const auto output_ = SAT::collision_detection(body_a, body_b);
+
+    EXPECT_TRUE(output_.has_value());
+
+    const CollisionInformation output = output_.value();
+    EXPECT_EQ(ContactType::EDGE_EDGE, output.contact_type);
+    EXPECT_EQ(2, output.contact_patch.size());
+    expect_near(glm::vec3(0.0, -5.0, 0.0), output.contact_patch[0], MAX_DIFF);
+    expect_near(glm::vec3(0.0, 5.0, 0.0), output.contact_patch[1], MAX_DIFF);
+    EXPECT_EQ(glm::vec3(-1.0, 0.0, 0.0), output.normal);
+    EXPECT_EQ(1.0, output.penetration_depth);
+    EXPECT_EQ(0, output.deepest_contact_idx);
 }
 
 TEST(
     SATTest,
     GivenRectanglesAreAxisAlignedAndOffsetFromOrigoWhenOverlappingOnXAxisExpectCollision) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(-10.0, 20.0, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(20.0, 10.0)};
-    RigidBody body_b = RigidBody{.position = WorldPoint(-10.0, 15.0, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(20.0, 10.0)};
-    auto output = SAT::collision_detection(body_a, body_b);
-    CollisionInformation expected = {.penetration_depth = 5.0,
-                                     .normal = glm::vec3(0.0, -1.0, 0.0),
-                                     .collision_point = glm::vec3(0.0, 20.0, 0.0)};
-    float max_diff = 1e-3;
-    EXPECT_TRUE(output.has_value());
-    expect_near(expected, output.value(), max_diff);
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(-10.0, 20.0, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(20.0, 10.0))
+                                 .build();
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(-10.0, 15.0, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(20.0, 10.0))
+                                 .build();
+    const auto output_ = SAT::collision_detection(body_a, body_b);
+
+    EXPECT_TRUE(output_.has_value());
+
+    const CollisionInformation output = output_.value();
+    EXPECT_EQ(ContactType::EDGE_EDGE, output.contact_type);
+    EXPECT_EQ(2, output.contact_patch.size());
+    expect_near(glm::vec3(0.0, 20.0, 0.0), output.contact_patch[0], MAX_DIFF);
+    expect_near(glm::vec3(-20.0, 20.0, 0.0), output.contact_patch[1], MAX_DIFF);
+    EXPECT_EQ(glm::vec3(0.0, -1.0, 0.0), output.normal);
+    EXPECT_EQ(5.0, output.penetration_depth);
+    EXPECT_EQ(0, output.deepest_contact_idx);
 }
 
 TEST(
     SATTest,
     GivenOneRectangleIsAxisAlignedAndOneRotated90DegreesWhenOverlapOnYAxisExpectCollision) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(10.0, 0.0, 0.0),
-                                 .rotation = glm::radians(-90.0f),
-                                 .shape = Shape::create_rectangle_data(20.0, 10.0)};
-    RigidBody body_b = RigidBody{.position = WorldPoint(0.0, 0.0, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(20.0, 10.0)};
-    auto output = SAT::collision_detection(body_a, body_b);
-    CollisionInformation expected = {.penetration_depth = 5.0,
-                                     .normal = glm::vec3(-1.0, 0.0, 0.0),
-                                     .collision_point = glm::vec3(10.0, -5.0, 0.0)};
-    float max_diff = 1e-3;
-    EXPECT_TRUE(output.has_value());
-    expect_near(expected, output.value(), max_diff);
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(10.0, 0.0, 0.0))
+                                 .rotation(glm::radians(-90.0f))
+                                 .shape(Shape::create_rectangle_data(20.0, 10.0))
+                                 .build();
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(0.0, 0.0, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(20.0, 10.0))
+                                 .build();
+    const auto output_ = SAT::collision_detection(body_a, body_b);
+
+    EXPECT_TRUE(output_.has_value());
+
+    const CollisionInformation output = output_.value();
+    EXPECT_EQ(ContactType::EDGE_EDGE, output.contact_type);
+    EXPECT_EQ(2, output.contact_patch.size());
+    expect_near(glm::vec3(10.0, -5.0, 0.0), output.contact_patch[0], MAX_DIFF);
+    expect_near(glm::vec3(10.0, 5.0, 0.0), output.contact_patch[1], MAX_DIFF);
+    expect_near(glm::vec3(-1.0, 0.0, 0.0), output.normal, MAX_DIFF);
+    EXPECT_EQ(5.0, output.penetration_depth);
+    EXPECT_EQ(0, output.deepest_contact_idx);
 }
 
 TEST(SATTest, GivenRectanglesAreRotated45DegreesWhenTheirSidesOverlapExpectCollision) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(0.0, 0.0, 0.0),
-                                 .rotation = glm::radians(-45.0f),
-                                 .shape = Shape::create_rectangle_data(10.0, 10.0)};
-    RigidBody body_b = RigidBody{.position = WorldPoint(6.071, 6.071, 0.0),
-                                 .rotation = glm::radians(-45.0f),
-                                 .shape = Shape::create_rectangle_data(10.0, 10.0)};
-    auto output = SAT::collision_detection(body_a, body_b);
-    CollisionInformation expected = {.penetration_depth = 1.414f,
-                                     .normal = glm::vec3(0.707f, 0.707f, 0.0f),
-                                     .collision_point = glm::vec3(-1.0f, 6.071f, 0.0f)};
-    float max_diff = 1e-3;
-    EXPECT_TRUE(output.has_value());
-    expect_near(expected, output.value(), max_diff);
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(0.0, 0.0, 0.0))
+                                 .rotation(glm::radians(-45.0f))
+                                 .shape(Shape::create_rectangle_data(10.0, 10.0))
+                                 .build();
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(6.071, 6.071, 0.0))
+                                 .rotation(glm::radians(-45.0f))
+                                 .shape(Shape::create_rectangle_data(10.0, 10.0))
+                                 .build();
+    const auto output_ = SAT::collision_detection(body_a, body_b);
+
+    EXPECT_TRUE(output_.has_value());
+
+    const CollisionInformation output = output_.value();
+    EXPECT_EQ(ContactType::EDGE_EDGE, output.contact_type);
+    EXPECT_EQ(2, output.contact_patch.size());
+    expect_near(glm::vec3(-1.0f, 6.071f, 0.0), output.contact_patch[0], MAX_DIFF);
+    expect_near(glm::vec3(6.071f, -1.0f, 0.0), output.contact_patch[1], MAX_DIFF);
+    expect_near(glm::vec3(0.707f, 0.707f, 0.0), output.normal, MAX_DIFF);
+    EXPECT_NEAR(1.414f, output.penetration_depth, MAX_DIFF);
+    EXPECT_EQ(0, output.deepest_contact_idx);
 }
 
 TEST(SATTest, GivenRectanglesAreRotatedNeg45DegreesWhenTheirSidesOverlapExpectCollision) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(0.0, 0.0, 0.0),
-                                 .rotation = glm::radians(45.0f),
-                                 .shape = Shape::create_rectangle_data(10.0, 10.0)};
-    RigidBody body_b = RigidBody{.position = WorldPoint(5.0, -5.0, 0.0),
-                                 .rotation = glm::radians(-45.0f),
-                                 .shape = Shape::create_rectangle_data(10.0, 10.0)};
-    auto output = SAT::collision_detection(body_a, body_b);
-    CollisionInformation expected = {.penetration_depth = 2.929f,
-                                     .normal = glm::vec3(0.707f, -0.707f, 0.0f),
-                                     .collision_point = glm::vec3(5.0f, 2.071f, 0.0f)};
-    float max_diff = 1e-3;
-    EXPECT_TRUE(output.has_value());
-    expect_near(expected, output.value(), max_diff);
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(0.0, 0.0, 0.0))
+                                 .rotation(glm::radians(45.0f))
+                                 .shape(Shape::create_rectangle_data(10.0, 10.0))
+                                 .build();
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(5.0, -5.0, 0.0))
+                                 .rotation(glm::radians(-45.0f))
+                                 .shape(Shape::create_rectangle_data(10.0, 10.0))
+                                 .build();
+    const auto output_ = SAT::collision_detection(body_a, body_b);
+
+    EXPECT_TRUE(output_.has_value());
+
+    const CollisionInformation output = output_.value();
+    EXPECT_EQ(ContactType::EDGE_EDGE, output.contact_type);
+    EXPECT_EQ(2, output.contact_patch.size());
+    expect_near(glm::vec3(5.0f, 2.071f, 0.0), output.contact_patch[0], MAX_DIFF);
+    expect_near(glm::vec3(-2.071f, -5.0f, 0.0), output.contact_patch[1], MAX_DIFF);
+    expect_near(glm::vec3(0.707f, -0.707f, 0.0), output.normal, MAX_DIFF);
+    EXPECT_NEAR(2.929f, output.penetration_depth, MAX_DIFF);
+    EXPECT_EQ(0, output.deepest_contact_idx);
 }
 
 TEST(SATTest,
      GivenRectanglesAreRotatedNeg45DegreesWhenTheirCornersOverlapExpectCollision) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(-5.0, 0.0, 0.0),
-                                 .rotation = glm::radians(45.0f),
-                                 .shape = Shape::create_rectangle_data(10.0, 10.0)};
-    RigidBody body_b = RigidBody{.position = WorldPoint(5.0, 0.0, 0.0),
-                                 .rotation = glm::radians(-45.0f),
-                                 .shape = Shape::create_rectangle_data(10.0, 10.0)};
-    auto output = SAT::collision_detection(body_a, body_b);
-    CollisionInformation expected = {.penetration_depth = 2.929f,
-                                     .normal = glm::vec3(0.707f, -0.707f, 0.0f),
-                                     .collision_point = glm::vec3(-2.071f, 0.0f, 0.0f)};
-    float max_diff = 1e-3;
-    EXPECT_TRUE(output.has_value());
-    expect_near(expected, output.value(), max_diff);
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(-5.0, 0.0, 0.0))
+                                 .rotation(glm::radians(45.0f))
+                                 .shape(Shape::create_rectangle_data(10.0, 10.0))
+                                 .build();
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(5.0, 0.0, 0.0))
+                                 .rotation(glm::radians(-45.0f))
+                                 .shape(Shape::create_rectangle_data(10.0, 10.0))
+                                 .build();
+    const auto output_ = SAT::collision_detection(body_a, body_b);
+    EXPECT_TRUE(output_.has_value());
+    const CollisionInformation output = output_.value();
+
+    EXPECT_EQ(ContactType::EDGE_EDGE, output.contact_type);
+    EXPECT_EQ(2, output.contact_patch.size());
+    expect_near(glm::vec3(-2.071f, 0.0f, 0.0), output.contact_patch[0], MAX_DIFF);
+    expect_near(glm::vec3(0.0f, 2.071f, 0.0), output.contact_patch[1], MAX_DIFF);
+    expect_near(glm::vec3(0.707f, -0.707f, 0.0), output.normal, MAX_DIFF);
+    EXPECT_NEAR(2.929f, output.penetration_depth, MAX_DIFF);
+    EXPECT_EQ(0, output.deepest_contact_idx);
 }
 
 TEST(SATTest,
      GivenRectanglesAreOffsetFromEachOtherWithNoRotationWithHalfOverlapExpectCollision) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(-4.0, 2.5, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(10.0, 10.0)};
-    RigidBody body_b = RigidBody{.position = WorldPoint(4.0, -2.5, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(10.0, 10.0)};
-    auto output = SAT::collision_detection(body_a, body_b);
-    CollisionInformation expected = {.penetration_depth = 2.0f,
-                                     .normal = glm::vec3(1.0f, 0.0f, 0.0f),
-                                     .collision_point = glm::vec3(-1.0f, 2.5f, 0.0f)};
-    float max_diff = 1e-3;
-    EXPECT_TRUE(output.has_value());
-    expect_near(expected, output.value(), max_diff);
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(-4.0, 2.5, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(10.0, 10.0))
+                                 .build();
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(4.0, -2.5, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(10.0, 10.0))
+                                 .build();
+    const auto output_ = SAT::collision_detection(body_a, body_b);
+    EXPECT_TRUE(output_.has_value());
+    const CollisionInformation output = output_.value();
+
+    EXPECT_EQ(ContactType::EDGE_EDGE, output.contact_type);
+    EXPECT_EQ(2, output.contact_patch.size());
+    expect_near(glm::vec3(-1.0, 2.5f, 0.0), output.contact_patch[0], MAX_DIFF);
+    expect_near(glm::vec3(-1.0, -2.5f, 0.0), output.contact_patch[1], MAX_DIFF);
+    expect_near(glm::vec3(1.0f, 0.0, 0.0), output.normal, MAX_DIFF);
+    EXPECT_NEAR(2.0f, output.penetration_depth, MAX_DIFF);
+    EXPECT_EQ(0, output.deepest_contact_idx);
 }
 
 TEST(SATTest,
      GivenRectanglesAreOffsetFromEachOtherWithNoRotationWithHalfOverlapExpectCollision2) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(4.0, 2.5, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(10.0, 10.0)};
-    RigidBody body_b = RigidBody{.position = WorldPoint(-4.0, -2.5, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(10.0, 10.0)};
-    auto output = SAT::collision_detection(body_a, body_b);
-    CollisionInformation expected = {.penetration_depth = 2.0f,
-                                     .normal = glm::vec3(-1.0f, 0.0f, 0.0f),
-                                     .collision_point = glm::vec3(1.0f, 2.5f, 0.0f)};
-    float max_diff = 1e-3;
-    EXPECT_TRUE(output.has_value());
-    expect_near(expected, output.value(), max_diff);
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(4.0, 2.5, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(10.0, 10.0))
+                                 .build();
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(-4.0, -2.5, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(10.0, 10.0))
+                                 .build();
+
+    const auto output_ = SAT::collision_detection(body_a, body_b);
+    EXPECT_TRUE(output_.has_value());
+    const CollisionInformation output = output_.value();
+
+    EXPECT_EQ(ContactType::EDGE_EDGE, output.contact_type);
+    EXPECT_EQ(2, output.contact_patch.size());
+    expect_near(glm::vec3(1.0, 2.5f, 0.0), output.contact_patch[0], MAX_DIFF);
+    expect_near(glm::vec3(1.0, -2.5f, 0.0), output.contact_patch[1], MAX_DIFF);
+    expect_near(glm::vec3(-1.0f, 0.0, 0.0), output.normal, MAX_DIFF);
+    EXPECT_NEAR(2.0f, output.penetration_depth, MAX_DIFF);
+    EXPECT_EQ(0, output.deepest_contact_idx);
 }
 
 // https://dyn4j.org/2011/11/contact-points-using-clipping/
 TEST(SATTest, GivenExample1AtDyn4jTestFindClippingPoints) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(11.0, 6.5, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(6.0, 5.0)};
+    RigidBody body_a = RigidBodyBuilder()
+                           .position(WorldPoint(11.0, 6.5, 0.0))
+                           .rotation(0.0)
+                           .shape(Shape::create_rectangle_data(6.0, 5.0))
+                           .build();
 
-    RigidBody body_b = RigidBody{.position = WorldPoint(8.0, 3.5, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(8.0, 3.0)};
+    RigidBody body_b = RigidBodyBuilder()
+                           .position(WorldPoint(8.0, 3.5, 0.0))
+                           .rotation(0.0)
+                           .shape(Shape::create_rectangle_data(8.0, 3.0))
+                           .build();
 
     glm::vec3 collision_axis = glm::vec3(0.0, -1.0, 0.0);
-    std::vector<ClippedPoint> output =
-        sat_find_clipping_points(body_a, body_b, collision_axis);
+    auto edge_a = find_collision_edge(body_a, collision_axis);
+    auto edge_b = find_collision_edge(body_b, -collision_axis);
 
-    ClippedPoint expected_0 =
-        ClippedPoint{.vertex = glm::vec3(12.0, 5.0, 0.0), .depth = 1.0};
-    ClippedPoint expected_1 =
-        ClippedPoint{.vertex = glm::vec3(8.0, 5.0, 0.0), .depth = 1.0};
+    CollisionInformation output = find_clipping_points(edge_a, edge_b, collision_axis);
 
-    float max_diff = 1e-3;
-    expect_near(expected_0, output[0], max_diff);
-    expect_near(expected_1, output[1], max_diff);
+    EXPECT_EQ(ContactType::EDGE_EDGE, output.contact_type);
+    EXPECT_EQ(2, output.contact_patch.size());
+    EXPECT_EQ(glm::vec3(12.0, 5.0, 0.0), output.contact_patch[0]);
+    EXPECT_EQ(glm::vec3(8.0, 5.0, 0.0), output.contact_patch[1]);
+    EXPECT_EQ(0, output.deepest_contact_idx);
+    EXPECT_NEAR(1.0, output.penetration_depth, MAX_DIFF);
 }
 
 // https://dyn4j.org/2011/11/contact-points-using-clipping/
 TEST(SATTest, GivenBodiesOverlapWhenAxisIsDownTestFindClippingPoints) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(10.0, 10.0, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(6.0, 6.0)};
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(10.0, 10.0, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(6.0, 6.0))
+                                 .build();
 
-    RigidBody body_b = RigidBody{.position = WorldPoint(13.0, 6.0, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(8.0, 4.0)};
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(13.0, 6.0, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(8.0, 4.0))
+                                 .build();
 
-    glm::vec3 collision_axis = glm::vec3(0.0, -1.0, 0.0);
-    std::vector<ClippedPoint> output =
-        sat_find_clipping_points(body_a, body_b, collision_axis);
+    const glm::vec3 collision_axis = glm::vec3(0.0, -1.0, 0.0);
+    const auto edge_a = find_collision_edge(body_a, collision_axis);
+    const auto edge_b = find_collision_edge(body_b, -collision_axis);
 
-    ClippedPoint expected_0 =
-        ClippedPoint{.vertex = glm::vec3(9.0, 8.0, 0.0), .depth = 1.0};
-    ClippedPoint expected_1 =
-        ClippedPoint{.vertex = glm::vec3(13.0, 8.0, 0.0), .depth = 1.0};
+    const CollisionInformation output =
+        find_clipping_points(edge_a, edge_b, collision_axis);
 
-    float max_diff = 1e-3;
-    expect_near(expected_0, output[0], max_diff);
-    expect_near(expected_1, output[1], max_diff);
+    EXPECT_EQ(ContactType::EDGE_EDGE, output.contact_type);
+    EXPECT_EQ(2, output.contact_patch.size());
+    expect_near(glm::vec3(9.0, 8.0, 0.0), output.contact_patch[0], MAX_DIFF);
+    expect_near(glm::vec3(13.0, 8.0, 0.0), output.contact_patch[1], MAX_DIFF);
+    EXPECT_EQ(0, output.deepest_contact_idx);
+    EXPECT_NEAR(1.0, output.penetration_depth, MAX_DIFF);
 }
 
 // https://dyn4j.org/2011/11/contact-points-using-clipping/
 TEST(SATTest, GivenExample2AtDyn4jTestFindClippingPoints) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(5.5, 7.5, 0.0),
-                                 .rotation = glm::pi<float>() / 4.0,
-                                 .shape = Shape::create_rectangle_data(5.6568, 4.2426)};
+    const RigidBody body_a =
+        RigidBody{.position = WorldPoint(5.5, 7.5, 0.0),
+                  .rotation = glm::radians(45.0),
+                  .shape = Shape::create_rectangle_data(5.6568, 4.2426)};
 
-    RigidBody body_b = RigidBody{.position = WorldPoint(8.0, 3.5, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(8.0, 3.0)};
+    const RigidBody body_b = RigidBody{.position = WorldPoint(8.0, 3.5, 0.0),
+                                       .rotation = 0.0,
+                                       .shape = Shape::create_rectangle_data(8.0, 3.0)};
 
-    glm::vec3 collision_axis = glm::vec3(0.0, -1.0, 0.0);
-    std::vector<ClippedPoint> output =
-        sat_find_clipping_points(body_a, body_b, collision_axis);
+    const glm::vec3 collision_axis = glm::vec3(0.0, -1.0, 0.0);
+    const auto edge_a = find_collision_edge(body_a, collision_axis);
+    const auto edge_b = find_collision_edge(body_b, -collision_axis);
 
-    ClippedPoint expected_0 =
-        ClippedPoint{.vertex = glm::vec3(6.0, 4.0, 0.0), .depth = 1.0};
+    const CollisionInformation output =
+        find_clipping_points(edge_a, edge_b, collision_axis);
 
-    float max_diff = 1e-3;
-    expect_near(expected_0, output[0], max_diff);
+    EXPECT_EQ(ContactType::VERTEX_EDGE, output.contact_type);
+    EXPECT_EQ(1, output.contact_patch.size());
+    expect_near(glm::vec3(6.0, 4.0, 0.0), output.contact_patch[0], MAX_DIFF);
+    EXPECT_EQ(0, output.deepest_contact_idx);
+    EXPECT_NEAR(1.0, output.penetration_depth, MAX_DIFF);
 }
 
 // https://dyn4j.org/2011/11/contact-points-using-clipping/
 TEST(SATTest, GivenExample3AtDyn4jTestFindClippingPoints) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(11.5, 5.5, 0.0),
-                                 .rotation = 0.2449,
-                                 .shape = Shape::create_rectangle_data(4.1231, 4.1231)};
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(11.5, 5.5, 0.0))
+                                 .rotation(0.2449)
+                                 .shape(Shape::create_rectangle_data(4.1231, 4.1231))
+                                 .build();
 
-    RigidBody body_b = RigidBody{.position = WorldPoint(8.0, 3.5, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(8.0, 3.0)};
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(8.0, 3.5, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(8.0, 3.0))
+                                 .build();
 
-    glm::vec3 collision_axis = glm::vec3(-0.19, -0.98, 0.0);
-    std::vector<ClippedPoint> output =
-        sat_find_clipping_points(body_a, body_b, collision_axis);
+    const glm::vec3 collision_axis = glm::vec3(-0.19, -0.98, 0.0);
+    const auto edge_a = find_collision_edge(body_a, collision_axis);
+    const auto edge_b = find_collision_edge(body_b, -collision_axis);
 
-    ClippedPoint expected_0 =
-        ClippedPoint{.vertex = glm::vec3(12.0, 5.0, 0.0), .depth = 1.698};
-    ClippedPoint expected_1 =
-        ClippedPoint{.vertex = glm::vec3(9.25, 5.0, 0.0), .depth = 1.031};
+    const CollisionInformation output =
+        find_clipping_points(edge_a, edge_b, collision_axis);
 
-    float max_diff = 1e-3;
-    expect_near(expected_0, output[0], max_diff);
-    expect_near(expected_1, output[1], max_diff);
+    EXPECT_EQ(ContactType::VERTEX_EDGE, output.contact_type);
+    EXPECT_EQ(2, output.contact_patch.size());
+    expect_near(glm::vec3(12.0, 5.0, 0.0), output.contact_patch[0], MAX_DIFF);
+    expect_near(glm::vec3(9.25, 5.0, 0.0), output.contact_patch[1], MAX_DIFF);
+    EXPECT_EQ(0, output.deepest_contact_idx);
+    EXPECT_NEAR(1.698, output.penetration_depth, MAX_DIFF);
 }
 
 // https://dyn4j.org/2011/11/contact-points-using-clipping/
 TEST(SATTest, GivenExample1BodyAAtDyn4jTestFindCollisionEdge) {
-    RigidBody test_body = RigidBody{.position = WorldPoint(11.0, 6.5, 0.0),
-                                    .rotation = 0.0,
-                                    .shape = Shape::create_rectangle_data(6.0, 5.0)};
+    const RigidBody test_body = RigidBodyBuilder()
+                                    .position(WorldPoint(11.0, 6.5, 0.0))
+                                    .rotation(0.0)
+                                    .shape(Shape::create_rectangle_data(6.0, 5.0))
+                                    .build();
 
-    glm::vec3 collision_axis = glm::vec3(0.0, -1.0, 0.0);
-    CollisionEdge output = sat_find_collision_edge(test_body, collision_axis);
+    const glm::vec3 collision_axis = glm::vec3(0.0, -1.0, 0.0);
+    const CollisionEdge output = find_collision_edge(test_body, collision_axis);
 
-    CollisionEdge expected = CollisionEdge{.max = glm::vec3(8.0, 4.0, 0.0),
-                                           .start = glm::vec3(8.0, 4.0, 0.0),
-                                           .end = glm::vec3(14.0, 4.0, 0.0),
-                                           .edge = glm::vec3(6.0, 0.0, 0.0)};
-    float max_diff = 1e-3;
-    expect_near(expected, output, max_diff);
+    const CollisionEdge expected = CollisionEdge{.max = glm::vec3(8.0, 4.0, 0.0),
+                                                 .start = glm::vec3(8.0, 4.0, 0.0),
+                                                 .end = glm::vec3(14.0, 4.0, 0.0),
+                                                 .edge = glm::vec3(6.0, 0.0, 0.0)};
+    expect_near(expected, output, MAX_DIFF);
 }
 
 // https://dyn4j.org/2011/11/contact-points-using-clipping/
 TEST(SATTest, GivenExample1BodyBAtDyn4jTestFindCollisionEdge) {
-    RigidBody test_body = RigidBody{.position = WorldPoint(8.0, 3.5, 0.0),
-                                    .rotation = 0.0,
-                                    .shape = Shape::create_rectangle_data(8.0, 3.0)};
+    const RigidBody test_body = RigidBodyBuilder()
+                                    .position(WorldPoint(8.0, 3.5, 0.0))
+                                    .rotation(0.0)
+                                    .shape(Shape::create_rectangle_data(8.0, 3.0))
+                                    .build();
 
-    glm::vec3 collision_axis = glm::vec3(0.0, 1.0, 0.0);
-    CollisionEdge output = sat_find_collision_edge(test_body, collision_axis);
+    const glm::vec3 collision_axis = glm::vec3(0.0, 1.0, 0.0);
+    const CollisionEdge output = find_collision_edge(test_body, collision_axis);
 
-    CollisionEdge expected = CollisionEdge{// NOTE: The below commented value is the
-                                           // result according to the example. However,
-                                           // the implementation does not yield that
-                                           // result, instead it yields the used .max
-                                           // value. I do not think it matters because it
-                                           // is resolved by letting the other bodys edge
-                                           // be the reference edge.
-                                           /*.max = glm::vec3(12.0, 5.0, 0.0),*/
-                                           .max = glm::vec3(4.0, 5.0, 0.0),
-                                           .start = glm::vec3(12.0, 5.0, 0.0),
-                                           .end = glm::vec3(4.0, 5.0, 0.0),
-                                           .edge = glm::vec3(-8.0, 0.0, 0.0)};
-    float max_diff = 1e-3;
+    const CollisionEdge expected =
+        CollisionEdge{// NOTE: The below commented value is the
+                      // result according to the example. However,
+                      // the implementation does not yield that
+                      // result, instead it yields the used .max
+                      // value. I do not think it matters because it
+                      // is resolved by letting the other bodys edge
+                      // be the reference edge.
+                      /*.max = glm::vec3(12.0, 5.0, 0.0),*/
+                      .max = glm::vec3(4.0, 5.0, 0.0),
+                      .start = glm::vec3(12.0, 5.0, 0.0),
+                      .end = glm::vec3(4.0, 5.0, 0.0),
+                      .edge = glm::vec3(-8.0, 0.0, 0.0)};
     EXPECT_EQ(expected.max, output.max)
         << "Expected " << expected.max << " found " << output.max;
     EXPECT_EQ(expected.start, output.start)
@@ -359,35 +444,41 @@ TEST(SATTest, GivenExample1BodyBAtDyn4jTestFindCollisionEdge) {
 }
 
 TEST(SATTest, GivenOffsetTriangleWithNoRotationTestFindCollisionEdgeOnBodyA) {
-    RigidBody test_body = RigidBody{.position = WorldPoint(-4.0f, 0.0, 0.0),
-                                    .rotation = 0.0,
-                                    .shape = Shape::create_triangle_data(10.0)};
+    const RigidBody test_body = RigidBodyBuilder()
+                                    .position(WorldPoint(-4.0f, 0.0, 0.0))
+                                    .rotation(0.0)
+                                    .shape(Shape::create_triangle_data(10.0))
+                                    .build();
 
-    MTV mtv = MTV{.direction = glm::vec3(0.866025f, -0.5f, 0.0f), .magnitude = 1.732f};
-    CollisionEdge output = sat_find_collision_edge(test_body, mtv.direction);
-    CollisionEdge expected = CollisionEdge{.max = glm::vec3(1.0f, -2.88675f, 0.0f),
-                                           .start = glm::vec3(-9.0f, -2.88675f, 0.0f),
-                                           .end = glm::vec3(1.0f, -2.88675f, 0.0f),
-                                           .edge = glm::vec3(10.0f, 0.0f, 0.0f)};
+    const MTV mtv =
+        MTV{.direction = glm::vec3(0.866025f, -0.5f, 0.0f), .magnitude = 1.732f};
+    const CollisionEdge output = find_collision_edge(test_body, mtv.direction);
+    const CollisionEdge expected =
+        CollisionEdge{.max = glm::vec3(1.0f, -2.88675f, 0.0f),
+                      .start = glm::vec3(-9.0f, -2.88675f, 0.0f),
+                      .end = glm::vec3(1.0f, -2.88675f, 0.0f),
+                      .edge = glm::vec3(10.0f, 0.0f, 0.0f)};
 
-    float max_diff = 1e-3;
-    expect_near(expected, output, max_diff);
+    expect_near(expected, output, MAX_DIFF);
 }
 
 TEST(SATTest, GivenOffsetTriangleWithNoRotationTestFindCollisionEdgeOnBodyB) {
-    RigidBody test_body = RigidBody{.position = WorldPoint(4.0f, 0.0, 0.0),
-                                    .rotation = 0.0,
-                                    .shape = Shape::create_triangle_data(10.0)};
+    const RigidBody test_body = RigidBodyBuilder()
+                                    .position(WorldPoint(4.0f, 0.0, 0.0))
+                                    .rotation(0.0)
+                                    .shape(Shape::create_triangle_data(10.0))
+                                    .build();
 
-    MTV mtv = MTV{.direction = glm::vec3(-0.866025f, 0.5f, 0.0f), .magnitude = 1.732f};
-    CollisionEdge output = sat_find_collision_edge(test_body, mtv.direction);
-    CollisionEdge expected = CollisionEdge{.max = glm::vec3(4.0f, 5.7735f, 0.0f),
-                                           .start = glm::vec3(4.0f, 5.7735f, 0.0f),
-                                           .end = glm::vec3(-1.0f, -2.88675f, 0.0f),
-                                           .edge = glm::vec3(-5.0f, -8.66025f, 0.0f)};
+    const MTV mtv =
+        MTV{.direction = glm::vec3(-0.866025f, 0.5f, 0.0f), .magnitude = 1.732f};
+    const CollisionEdge output = find_collision_edge(test_body, mtv.direction);
+    const CollisionEdge expected =
+        CollisionEdge{.max = glm::vec3(4.0f, 5.7735f, 0.0f),
+                      .start = glm::vec3(4.0f, 5.7735f, 0.0f),
+                      .end = glm::vec3(-1.0f, -2.88675f, 0.0f),
+                      .edge = glm::vec3(-5.0f, -8.66025f, 0.0f)};
 
-    float max_diff = 1e-3;
-    expect_near(expected, output, max_diff);
+    expect_near(expected, output, MAX_DIFF);
 }
 
 // https://dyn4j.org/2011/11/contact-points-using-clipping/
@@ -398,109 +489,118 @@ TEST(SATTest, GivenExample2BodyAAtDyn4jTestFindCollisionEdge) {
                   .shape = Shape::create_rectangle_data(5.6568, 4.2426)};
 
     glm::vec3 collision_axis = glm::vec3(0.0, -1.0, 0.0);
-    CollisionEdge output = sat_find_collision_edge(test_body, collision_axis);
+    CollisionEdge output = find_collision_edge(test_body, collision_axis);
 
     CollisionEdge expected = CollisionEdge{.max = glm::vec3(6.0, 4.0, 0.0),
                                            .start = glm::vec3(2.0, 8.0, 0.0),
                                            .end = glm::vec3(6.0, 4.0, 0.0),
                                            .edge = glm::vec3(4.0, -4.0, 0.0)};
-    float max_diff = 1e-3;
-    expect_near(expected, output, max_diff);
+    expect_near(expected, output, MAX_DIFF);
 }
 
 // https://dyn4j.org/2011/11/contact-points-using-clipping/
 TEST(SATTest, GivenExample2BodyBAtDyn4jTestFindCollisionEdge) {
-    RigidBody test_body = RigidBody{.position = WorldPoint(8.0, 3.5, 0.0),
-                                    .rotation = 0.0,
-                                    .shape = Shape::create_rectangle_data(8.0, 3.0)};
+    const RigidBody test_body = RigidBodyBuilder()
+                                    .position(WorldPoint(8.0, 3.5, 0.0))
+                                    .rotation(0.0)
+                                    .shape(Shape::create_rectangle_data(8.0, 3.0))
+                                    .build();
 
-    glm::vec3 collision_axis = glm::vec3(0.0, 1.0, 0.0);
-    CollisionEdge output = sat_find_collision_edge(test_body, collision_axis);
+    const glm::vec3 collision_axis = glm::vec3(0.0, 1.0, 0.0);
+    const CollisionEdge output = find_collision_edge(test_body, collision_axis);
 
-    CollisionEdge expected = CollisionEdge{// NOTE: The below commented value is the
-                                           // result according to the example. However,
-                                           // the implementation does not yield that
-                                           // result, instead it yields the used .max
-                                           // value. I do not think it matters because it
-                                           // is resolved by letting the other bodys edge
-                                           // be the reference edge.
-                                           /*.max = glm::vec3(12.0, 5.0, 0.0),*/
-                                           .max = glm::vec3(4.0, 5.0, 0.0),
-                                           .start = glm::vec3(12.0, 5.0, 0.0),
-                                           .end = glm::vec3(4.0, 5.0, 0.0),
-                                           .edge = glm::vec3(-8.0, 0.0, 0.0)};
-    float max_diff = 1e-3;
-    expect_near(expected, output, max_diff);
+    const CollisionEdge expected =
+        CollisionEdge{// NOTE: The below commented value is the
+                      // result according to the example. However,
+                      // the implementation does not yield that
+                      // result, instead it yields the used .max
+                      // value. I do not think it matters because it
+                      // is resolved by letting the other bodys edge
+                      // be the reference edge.
+                      /*.max = glm::vec3(12.0, 5.0, 0.0),*/
+                      .max = glm::vec3(4.0, 5.0, 0.0),
+                      .start = glm::vec3(12.0, 5.0, 0.0),
+                      .end = glm::vec3(4.0, 5.0, 0.0),
+                      .edge = glm::vec3(-8.0, 0.0, 0.0)};
+    expect_near(expected, output, MAX_DIFF);
 }
 
 // https://dyn4j.org/2011/11/contact-points-using-clipping/
 TEST(SATTest, GivenExample3BodyAAtDyn4jTestFindCollisionEdge) {
-    RigidBody test_body =
+    const RigidBody test_body =
         RigidBody{.position = WorldPoint(11.5, 5.5, 0.0),
                   .rotation = 0.2449,
                   .shape = Shape::create_rectangle_data(4.1231, 4.1231)};
 
-    glm::vec3 collision_axis = glm::vec3(-0.19, -0.98, 0.0);
-    CollisionEdge output = sat_find_collision_edge(test_body, collision_axis);
+    const glm::vec3 collision_axis = glm::vec3(-0.19, -0.98, 0.0);
+    const CollisionEdge output = find_collision_edge(test_body, collision_axis);
 
-    CollisionEdge expected = CollisionEdge{.max = glm::vec3(13.0, 3.0, 0.0),
-                                           .start = glm::vec3(9.0, 4.0, 0.0),
-                                           .end = glm::vec3(13.0, 3.0, 0.0),
-                                           .edge = glm::vec3(4.0, -1.0, 0.0)};
-    float max_diff = 1e-3;
-    expect_near(expected, output, max_diff);
+    const CollisionEdge expected = CollisionEdge{.max = glm::vec3(13.0, 3.0, 0.0),
+                                                 .start = glm::vec3(9.0, 4.0, 0.0),
+                                                 .end = glm::vec3(13.0, 3.0, 0.0),
+                                                 .edge = glm::vec3(4.0, -1.0, 0.0)};
+    expect_near(expected, output, MAX_DIFF);
 }
 
 // https://dyn4j.org/2011/11/contact-points-using-clipping/
 TEST(SATTest, GivenExample3BodyBAtDyn4jTestFindCollisionEdge) {
-    RigidBody test_body = RigidBody{.position = WorldPoint(8.0, 3.5, 0.0),
-                                    .rotation = 0.0,
-                                    .shape = Shape::create_rectangle_data(8.0, 3.0)};
+    const RigidBody test_body = RigidBodyBuilder()
+                                    .position(WorldPoint(8.0, 3.5, 0.0))
+                                    .rotation(0.0)
+                                    .shape(Shape::create_rectangle_data(8.0, 3.0))
+                                    .build();
 
-    glm::vec3 collision_axis = glm::vec3(0.19, 0.98, 0.0);
-    CollisionEdge output = sat_find_collision_edge(test_body, collision_axis);
+    const glm::vec3 collision_axis = glm::vec3(0.19, 0.98, 0.0);
+    const CollisionEdge output = find_collision_edge(test_body, collision_axis);
 
-    CollisionEdge expected = CollisionEdge{.max = glm::vec3(12.0, 5.0, 0.0),
-                                           .start = glm::vec3(12.0, 5.0, 0.0),
-                                           .end = glm::vec3(4.0, 5.0, 0.0),
-                                           .edge = glm::vec3(-8.0, 0.0, 0.0)};
-    float max_diff = 1e-3;
-    expect_near(expected, output, max_diff);
+    const CollisionEdge expected = CollisionEdge{.max = glm::vec3(12.0, 5.0, 0.0),
+                                                 .start = glm::vec3(12.0, 5.0, 0.0),
+                                                 .end = glm::vec3(4.0, 5.0, 0.0),
+                                                 .edge = glm::vec3(-8.0, 0.0, 0.0)};
+    expect_near(expected, output, MAX_DIFF);
 }
 
 TEST(SATTest, GivenTwoTrianglesAreNotRotatedAndCollideAtCorners) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(-4.0f, 0.0, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_triangle_data(10.0)};
-    RigidBody body_b = RigidBody{.position = WorldPoint(4.0f, 0.0, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_triangle_data(10.0)};
-    glm::vec3 collision_axis = glm::vec3(0.19, 0.98, 0.0);
-    auto output_ = SAT::collision_detection(body_a, body_b);
-
-    CollisionInformation expected =
-        CollisionInformation{.collision_point = glm::vec3(1.0f, -2.88675f, 0.0f),
-                             .normal = glm::vec3(0.866025f, -0.5f, 0.0f),
-                             .penetration_depth = 1.73205f};
-    float max_diff = 1e-3;
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(-4.0f, 0.0, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_triangle_data(10.0))
+                                 .build();
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(4.0f, 0.0, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_triangle_data(10.0))
+                                 .build();
+    const auto output_ = SAT::collision_detection(body_a, body_b);
     EXPECT_TRUE(output_.has_value());
-    CollisionInformation output = output_.value();
-    expect_near(expected, output, max_diff);
+    const CollisionInformation output = output_.value();
+
+    EXPECT_EQ(ContactType::VERTEX_EDGE, output.contact_type);
+    EXPECT_EQ(2, output.contact_patch.size());
+    expect_near(glm::vec3(1.0, -2.88675f, 0.0), output.contact_patch[0], MAX_DIFF);
+    expect_near(glm::vec3(-1.0, -2.88675f, 0.0), output.contact_patch[1], MAX_DIFF);
+    expect_near(glm::vec3(0.866025f, -0.5, 0.0), output.normal, MAX_DIFF);
+    EXPECT_NEAR(1.73205f, output.penetration_depth, MAX_DIFF);
+    EXPECT_EQ(0, output.deepest_contact_idx);
 }
 
 TEST(SATTest, GivenExample1AtDyn4jTestFindMTV) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(11.0, 6.5, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(6.0, 5.0)};
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(11.0, 6.5, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(6.0, 5.0))
+                                 .build();
 
-    RigidBody body_b = RigidBody{.position = WorldPoint(8.0, 3.5, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(8.0, 3.0)};
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(8.0, 3.5, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(8.0, 3.0))
+                                 .build();
 
-    auto mtv_ = find_mtv(body_a, body_b);
+    const auto mtv_ = find_mtv(body_a, body_b);
     EXPECT_TRUE(mtv_.has_value());
-    MTV mtv = mtv_.value();
-    MTV expected = MTV{.direction = glm::vec3(0.0, -1.0, 0.0), .magnitude = 1.0};
+    const MTV mtv = mtv_.value();
+    const MTV expected = MTV{.direction = glm::vec3(0.0, -1.0, 0.0), .magnitude = 1.0};
 
     EXPECT_EQ(expected.direction, mtv.direction)
         << "Expected " << expected.direction << " found " << mtv.direction;
@@ -509,18 +609,22 @@ TEST(SATTest, GivenExample1AtDyn4jTestFindMTV) {
 }
 
 TEST(SATTest, GivenExample1AtDyn4jTestFindMTVSwap) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(11.0, 6.5, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(6.0, 5.0)};
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(11.0, 6.5, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(6.0, 5.0))
+                                 .build();
 
-    RigidBody body_b = RigidBody{.position = WorldPoint(8.0, 3.5, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(8.0, 3.0)};
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(8.0, 3.5, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(8.0, 3.0))
+                                 .build();
 
-    auto mtv_ = find_mtv(body_b, body_a);
+    const auto mtv_ = find_mtv(body_b, body_a);
     EXPECT_TRUE(mtv_.has_value());
-    MTV mtv = mtv_.value();
-    MTV expected = MTV{.direction = glm::vec3(0.0, 1.0, 0.0), .magnitude = 1.0};
+    const MTV mtv = mtv_.value();
+    const MTV expected = MTV{.direction = glm::vec3(0.0, 1.0, 0.0), .magnitude = 1.0};
 
     EXPECT_EQ(expected.direction, mtv.direction)
         << "Expected " << expected.direction << " found " << mtv.direction;
@@ -529,122 +633,148 @@ TEST(SATTest, GivenExample1AtDyn4jTestFindMTVSwap) {
 }
 
 TEST(SATTest, GivenTwoTrianglesTestFindMTV) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(-4.0f, 0.0, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_triangle_data(10.0)};
-    RigidBody body_b = RigidBody{.position = WorldPoint(4.0f, 0.0, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_triangle_data(10.0)};
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(-4.0f, 0.0, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_triangle_data(10.0))
+                                 .build();
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(4.0f, 0.0, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_triangle_data(10.0))
+                                 .build();
 
-    auto mtv_ = find_mtv(body_a, body_b);
+    const auto mtv_ = find_mtv(body_a, body_b);
 
     EXPECT_TRUE(mtv_.has_value());
-    MTV mtv = mtv_.value();
-    MTV expected = MTV{.direction = glm::vec3(0.866025, -0.5, 0), .magnitude = 1.732f};
+    const MTV mtv = mtv_.value();
+    const MTV expected =
+        MTV{.direction = glm::vec3(0.866025, -0.5, 0), .magnitude = 1.732f};
 
-    expect_near(expected.direction, mtv.direction, 1e-3f);
-    EXPECT_NEAR(expected.magnitude, mtv.magnitude, 1e-3f)
+    expect_near(expected.direction, mtv.direction, MAX_DIFF);
+    EXPECT_NEAR(expected.magnitude, mtv.magnitude, MAX_DIFF)
         << "Expected " << expected.magnitude << " found " << mtv.magnitude;
 }
 
 TEST(SATTest, GivenTwoTrianglesTestFindMTVSwap) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(-4.0f, 0.0, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_triangle_data(10.0)};
-    RigidBody body_b = RigidBody{.position = WorldPoint(4.0f, 0.0, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_triangle_data(10.0)};
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(-4.0f, 0.0, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_triangle_data(10.0))
+                                 .build();
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(4.0f, 0.0, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_triangle_data(10.0))
+                                 .build();
 
-    auto mtv_ = find_mtv(body_b, body_a);
+    const auto mtv_ = find_mtv(body_b, body_a);
 
     EXPECT_TRUE(mtv_.has_value());
-    MTV mtv = mtv_.value();
-    MTV expected = MTV{.direction = glm::vec3(-0.866025, 0.5, 0), .magnitude = 1.732f};
-    expect_near(expected.direction, mtv.direction, 1e-3f);
-    EXPECT_NEAR(expected.magnitude, mtv.magnitude, 1e-3f)
+    const MTV mtv = mtv_.value();
+    const MTV expected =
+        MTV{.direction = glm::vec3(-0.866025, 0.5, 0), .magnitude = 1.732f};
+    expect_near(expected.direction, mtv.direction, MAX_DIFF);
+    EXPECT_NEAR(expected.magnitude, mtv.magnitude, MAX_DIFF)
         << "Expected " << expected.magnitude << " found " << mtv.magnitude;
 }
 
 TEST(SATTest, GivenExample2AtDyn4jTestFindMTV) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(5.5, 7.5, 0.0),
-                                 .rotation = glm::pi<float>() / 4.0,
-                                 .shape = Shape::create_rectangle_data(5.6568, 4.2426)};
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(5.5, 7.5, 0.0))
+                                 .rotation(glm::pi<float>() / 4.0)
+                                 .shape(Shape::create_rectangle_data(5.6568, 4.2426))
+                                 .build();
 
-    RigidBody body_b = RigidBody{.position = WorldPoint(8.0, 3.5, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(8.0, 3.0)};
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(8.0, 3.5, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(8.0, 3.0))
+                                 .build();
 
-    auto mtv_ = find_mtv(body_a, body_b);
+    const auto mtv_ = find_mtv(body_a, body_b);
 
     EXPECT_TRUE(mtv_.has_value());
-    MTV mtv = mtv_.value();
-    MTV expected = MTV{.direction = glm::vec3(0.0, -1.0, 0.0), .magnitude = 1.0f};
+    const MTV mtv = mtv_.value();
+    const MTV expected = MTV{.direction = glm::vec3(0.0, -1.0, 0.0), .magnitude = 1.0f};
     expect_near(expected.direction, mtv.direction, 1e-3f);
     EXPECT_NEAR(expected.magnitude, mtv.magnitude, 1e-3f)
         << "Expected " << expected.magnitude << " found " << mtv.magnitude;
 }
 
 TEST(SATTest, GivenExample2AtDyn4jTestFindMTVSwap) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(5.5, 7.5, 0.0),
-                                 .rotation = glm::pi<float>() / 4.0,
-                                 .shape = Shape::create_rectangle_data(5.6568, 4.2426)};
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(5.5, 7.5, 0.0))
+                                 .rotation(glm::pi<float>() / 4.0)
+                                 .shape(Shape::create_rectangle_data(5.6568, 4.2426))
+                                 .build();
 
-    RigidBody body_b = RigidBody{.position = WorldPoint(8.0, 3.5, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(8.0, 3.0)};
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(8.0, 3.5, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(8.0, 3.0))
+                                 .build();
 
-    auto mtv_ = find_mtv(body_b, body_a);
+    const auto mtv_ = find_mtv(body_b, body_a);
 
     EXPECT_TRUE(mtv_.has_value());
-    MTV mtv = mtv_.value();
-    MTV expected = MTV{.direction = glm::vec3(0.0, 1.0, 0.0), .magnitude = 1.0f};
-    expect_near(expected.direction, mtv.direction, 1e-3f);
-    EXPECT_NEAR(expected.magnitude, mtv.magnitude, 1e-3f)
+    const MTV mtv = mtv_.value();
+    const MTV expected = MTV{.direction = glm::vec3(0.0, 1.0, 0.0), .magnitude = 1.0f};
+    expect_near(expected.direction, mtv.direction, MAX_DIFF);
+    EXPECT_NEAR(expected.magnitude, mtv.magnitude, MAX_DIFF)
         << "Expected " << expected.magnitude << " found " << mtv.magnitude;
 }
 
 TEST(SATTest, GivenExample3AtDyn4jTestFindMTV) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(11.5, 5.5, 0.0),
-                                 .rotation = 0.2449,
-                                 .shape = Shape::create_rectangle_data(4.1231, 4.1231)};
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(11.5, 5.5, 0.0))
+                                 .rotation(0.2449)
+                                 .shape(Shape::create_rectangle_data(4.1231, 4.1231))
+                                 .build();
 
-    RigidBody body_b = RigidBody{.position = WorldPoint(8.0, 3.5, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(8.0, 3.0)};
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(8.0, 3.5, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(8.0, 3.0))
+                                 .build();
 
-    auto mtv_ = find_mtv(body_a, body_b);
+    const auto mtv_ = find_mtv(body_a, body_b);
 
     EXPECT_TRUE(mtv_.has_value());
-    MTV mtv = mtv_.value();
+    const MTV mtv = mtv_.value();
     // NOTE: This normal does not equal the normal given in the example. Reason being
     // that I think that normal is wrong when a compute it from his vertices. However, the
     // two normals point in the same general direction as that normal is (-0.19, -0.98).
-    MTV expected =
+    const MTV expected =
         MTV{.direction = glm::vec3(-0.242459, -0.970162, 0), .magnitude = 1.697f};
-    expect_near(expected.direction, mtv.direction, 1e-3f);
-    EXPECT_NEAR(expected.magnitude, mtv.magnitude, 1e-3f)
+    expect_near(expected.direction, mtv.direction, MAX_DIFF);
+    EXPECT_NEAR(expected.magnitude, mtv.magnitude, MAX_DIFF)
         << "Expected " << expected.magnitude << " found " << mtv.magnitude;
 }
 
 TEST(SATTest, GivenExample3AtDyn4jTestFindMTVSwap) {
-    RigidBody body_a = RigidBody{.position = WorldPoint(11.5, 5.5, 0.0),
-                                 .rotation = 0.2449,
-                                 .shape = Shape::create_rectangle_data(4.1231, 4.1231)};
+    const RigidBody body_a = RigidBodyBuilder()
+                                 .position(WorldPoint(11.5, 5.5, 0.0))
+                                 .rotation(0.2449)
+                                 .shape(Shape::create_rectangle_data(4.1231, 4.1231))
+                                 .build();
 
-    RigidBody body_b = RigidBody{.position = WorldPoint(8.0, 3.5, 0.0),
-                                 .rotation = 0.0,
-                                 .shape = Shape::create_rectangle_data(8.0, 3.0)};
+    const RigidBody body_b = RigidBodyBuilder()
+                                 .position(WorldPoint(8.0, 3.5, 0.0))
+                                 .rotation(0.0)
+                                 .shape(Shape::create_rectangle_data(8.0, 3.0))
+                                 .build();
 
-    auto mtv_ = find_mtv(body_b, body_a);
+    const auto mtv_ = find_mtv(body_b, body_a);
 
     EXPECT_TRUE(mtv_.has_value());
-    MTV mtv = mtv_.value();
+    const MTV mtv = mtv_.value();
     // NOTE: This normal does not equal the normal given in the example. Reason being
     // that I think that normal is wrong when a compute it from his vertices. However, the
     // two normals point in the same general direction as that normal is (-0.19, -0.98).
-    MTV expected =
+    const MTV expected =
         MTV{.direction = glm::vec3(0.242459, 0.970162, 0), .magnitude = 1.697f};
-    expect_near(expected.direction, mtv.direction, 1e-3f);
-    EXPECT_NEAR(expected.magnitude, mtv.magnitude, 1e-3f)
+    expect_near(expected.direction, mtv.direction, MAX_DIFF);
+    EXPECT_NEAR(expected.magnitude, mtv.magnitude, MAX_DIFF)
         << "Expected " << expected.magnitude << " found " << mtv.magnitude;
 }

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -1,0 +1,8 @@
+#include "test_utils.h"
+
+void expect_near(const glm::vec3 &expected, const glm::vec3 &v, const float epsilon) {
+    std::cout << "Expected " << expected << " found " << v << std::endl;
+    EXPECT_NEAR(expected.x, v.x, epsilon);
+    EXPECT_NEAR(expected.y, v.y, epsilon);
+    EXPECT_NEAR(expected.z, v.z, epsilon);
+}

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "glm/glm.hpp"
+#include "io.h"
+#include <gtest/gtest.h>
+
+constexpr float MAX_DIFF = 1e-3;
+
+void expect_near(const glm::vec3 &expected, const glm::vec3 &v, const float epsilon);

--- a/tests/vector_equations_test.cpp
+++ b/tests/vector_equations_test.cpp
@@ -1,1 +1,0 @@
-#include <gtest/gtest.h>


### PR DESCRIPTION
With this commit the contact patch and the contact type during the collision is returned. In a future PR we will refactor the collision resolution step to properly apply collision correction depending on the contact type.